### PR TITLE
Improve CI workflows and update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yaml
@@ -9,7 +9,7 @@ body:
   - type: input
     id: what
     attributes:
-      label: WHAT IS ISSUE
+      label: What is your issue?
       description: What is wrong
       placeholder: It's not working...
     validations:
@@ -17,7 +17,7 @@ body:
   - type: textarea
     id: how
     attributes:
-      label: HOW DID HAPPEN
+      label: How did it happen?
       description: What happened to make the issue appear? The more detailed your breakdown is the easier it is to reproduce/debug/fix
       placeholder: |
         1. Turned on robot
@@ -39,6 +39,6 @@ body:
   - type: textarea
     id: misc
     attributes:
-      label: OTHER INFORMATION
-      description: Attach other useful information (i.e., a video of what happened) here. The more info we have the easier it should be to fix.
+      label: Other Information
+      description: Attach other useful information (e.g., a video of what happened) here. The more info we have the easier it should be to fix.
       placeholder: "Here is a video of what is happening: (you can click here and drag and drop or paste to upload media)"

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yaml
@@ -9,7 +9,7 @@ body:
   - type: textarea
     id: what
     attributes:
-      label: WHAT IS REQUEST
+      label: Request
       description: What do you want to add/request?
       placeholder: I need the robot to do this...
     validations:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,8 +2,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
-name: Build Vite App
-
+name: Check React formatting with Prettier
 on:
   push:
     branches: ["*"]
@@ -30,4 +29,4 @@ jobs:
           cache: "yarn"
           cache-dependency-path: app/yarn.lock
       - run: yarn
-      - run: yarn build
+      - run: yarn format:check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
-name: Build Vite App
+name: Run Vitest tests
 
 on:
   push:
@@ -30,4 +30,4 @@ jobs:
           cache: "yarn"
           cache-dependency-path: app/yarn.lock
       - run: yarn
-      - run: yarn build
+      - run: yarn test


### PR DESCRIPTION
This PR separates the CI into 3 different files so that tests, building, and formatting can all be checked independently. Previously, if formatting failed, everything would fail and you would not be able to know if your code compiled properly or if tests passed in CI. This might also increase speed slightly if GitHub will run these in parallel. Additionally issue templates got minor updates.

Closes #12 