### PR TITLE
Styling improvements

### DIFF
--- a/app/src/components/App.tsx
+++ b/app/src/components/App.tsx
@@ -14,16 +14,23 @@ function App() {
   const { globalStatus, setGlobalStatus } = useContext(GlobalStatusContext);
 
   return (
-    <Box height="100%">
+    <Box sx={{ height: "100dvh", display: "flex", flexDirection: "column" }}>
       <NavBar status={globalStatus} setStatus={setGlobalStatus} />
-      <Grid container spacing={2}>
-        <Grid size={3}>
+      <Grid
+        container
+        spacing={0}
+        sx={{
+          flexGrow: 1, // This makes the Grid take up all remaining space
+          overflow: "hidden", // Prevents scrolling issues
+        }}
+      >
+        <Grid size={4}>
           <NodeManager
             setSelectedNode={setSelectedNode}
             selectedNode={selectedNode}
           />
         </Grid>
-        <Grid size={9} height="100%">
+        <Grid size={8} height="100%">
           <Console
             selectedNode={selectedNode}
             clearSelectedNode={() => setSelectedNode(null)}

--- a/app/src/components/Console/Console.tsx
+++ b/app/src/components/Console/Console.tsx
@@ -14,7 +14,7 @@ import ConsoleFilters from "./ConsoleFilters";
  */
 function Console({ ...props }: Console) {
   const consoleTitle = props.selectedNode
-    ? `Messages from "${props.selectedNode}"`
+    ? `Console: ${props.selectedNode}`
     : "Console";
   const visibility = props.selectedNode ? undefined : { visibility: "hidden" };
   const consoleOutputRef = useRef<HTMLDivElement>(null);
@@ -121,7 +121,16 @@ function Console({ ...props }: Console) {
           justifyContent="space-between"
           alignItems="center"
         >
-          <Typography variant="h6">{consoleTitle}</Typography>
+          <Typography
+            variant="h6"
+            sx={{
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {consoleTitle}
+          </Typography>
           <IconButton
             onClick={props.clearSelectedNode}
             sx={{

--- a/app/src/components/Console/Console.tsx
+++ b/app/src/components/Console/Console.tsx
@@ -107,17 +107,33 @@ function Console({ ...props }: Console) {
   }
 
   return (
-    <Paper>
-      <Box sx={{ p: 1 }}>
+    <Paper
+      sx={{
+        height: "inherit",
+        display: "flex",
+        flexDirection: "column",
+        borderRadius: "20px 0 0 0",
+      }}
+    >
+      <Box sx={{ pl: 2, pr: 2, pt: 1.5 }}>
         <Stack
           direction="row"
           justifyContent="space-between"
           alignItems="center"
         >
-          <Typography>{consoleTitle}</Typography>
+          <Typography variant="h6">{consoleTitle}</Typography>
           <IconButton
             onClick={props.clearSelectedNode}
-            sx={{ borderRadius: 25, ...visibility }}
+            sx={{
+              borderRadius: 25,
+              scale: 0.95,
+              border: "1px solid",
+              borderColor: "lightgray",
+              ":hover": {
+                borderColor: "gray",
+              },
+              ...visibility,
+            }}
           >
             <Close />
           </IconButton>
@@ -135,9 +151,12 @@ function Console({ ...props }: Console) {
           bgcolor: "#222",
           height: "60vh",
           color: "#eee",
-          p: 1,
           textAlign: "left",
           overflow: "scroll",
+          flexGrow: 1,
+          borderRadius: "6px",
+          m: 1,
+          p: 1,
         }}
       >
         <pre style={{ margin: 0, padding: 0, whiteSpace: "pre-wrap" }}>

--- a/app/src/components/Console/ConsoleFilters.tsx
+++ b/app/src/components/Console/ConsoleFilters.tsx
@@ -116,7 +116,21 @@ function ConsoleFilters({ ...props }: ConsoleFilters) {
   }
 
   return (
-    <Box sx={{ width: "100%", display: "flex", alignItems: "center" }}>
+    <Box
+      sx={{
+        width: "100%",
+        display: "flex",
+        alignItems: "center",
+        overflowX: "scroll", // Only horizontal scroll
+        overflowY: "hidden", // Prevent vertical scroll
+        "&::-webkit-scrollbar": {
+          // Chrome, Safari, newer Edge
+          display: "none",
+        },
+        msOverflowStyle: "none", // IE and Edge
+        whiteSpace: "nowrap", // Keeps content in a single line
+      }}
+    >
       {renderToggleShowButton()}
       {renderFilterChips()}
     </Box>

--- a/app/src/components/Console/ConsoleFilters.tsx
+++ b/app/src/components/Console/ConsoleFilters.tsx
@@ -96,7 +96,13 @@ function ConsoleFilters({ ...props }: ConsoleFilters) {
   function renderToggleShowButton() {
     return (
       <ToggleButton
-        sx={{ borderRadius: 10, scale: 0.85 }}
+        sx={{
+          borderRadius: 10,
+          scale: 0.85,
+          ":hover": {
+            borderColor: "gray",
+          },
+        }}
         size="small"
         value="toggleShowFilters"
         selected={showFilters}

--- a/app/src/components/NavBar/NavBar.tsx
+++ b/app/src/components/NavBar/NavBar.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Box, Paper, Typography } from "@mui/material";
+import { Avatar, Box, Typography } from "@mui/material";
 import type { NavBar } from "../../types/navbar";
 import EStop from "./EStop";
 import StartButton from "./StartButton";
@@ -13,14 +13,13 @@ import StatusSummary from "./StatusSummary";
  */
 function NavBar({ ...props }: NavBar) {
   return (
-    <Paper
+    <Box
       sx={{
         display: "grid",
         gridTemplateColumns: "auto auto", // Two columns: left and right
         alignItems: "center",
         padding: "1rem",
         backgroundColor: "background.surface", // Use Joy UI theme background
-        mb: 2,
       }}
     >
       <Box sx={{ display: "flex", alignItems: "center" }}>
@@ -50,7 +49,7 @@ function NavBar({ ...props }: NavBar) {
         <StatusSummary status={props.status} />
         <StartButton status={props.status} setStatus={props.setStatus} />
       </Box>
-    </Paper>
+    </Box>
   );
 }
 

--- a/app/src/components/NavBar/StatusSummary.tsx
+++ b/app/src/components/NavBar/StatusSummary.tsx
@@ -16,6 +16,8 @@ function StatusSummary({ ...props }: StatusSummary) {
         paddingY: 1,
         paddingX: 2,
         borderRadius: 25,
+        border: "1px solid",
+        borderColor: "gray",
       }}
     >
       Status: {props.status}

--- a/app/src/components/NodeManager/NodeItem.tsx
+++ b/app/src/components/NodeManager/NodeItem.tsx
@@ -42,13 +42,22 @@ function NodeItem({ ...props }: NodeItem) {
         alignItems="center"
         sx={{ width: "100%" }}
       >
-        <Stack direction="row" alignItems="center">
-          <StatusIcon
-            status={props.status}
-            sx={{ ml: 0, mr: 1, ...selectedStatusBorder }}
-          />
-          <Typography>{props.name}</Typography>
-        </Stack>
+        <StatusIcon
+          status={props.status}
+          sx={{ ml: 0, mr: 1, ...selectedStatusBorder }}
+        />
+        <Box sx={{ flexGrow: 1, flexShrink: 1, minWidth: 0 }}>
+          <Typography
+            textAlign={"left"}
+            sx={{
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {props.name}
+          </Typography>
+        </Box>
         <Box
           sx={{
             height: "1.25em",
@@ -58,6 +67,7 @@ function NodeItem({ ...props }: NodeItem) {
             alignContent: "center",
             margin: 0,
             padding: 0,
+            flexShrink: 0,
           }}
         >
           <ChevronRightRounded sx={{ width: 1, height: 1, color: "black" }} />

--- a/app/src/components/NodeManager/NodeItem.tsx
+++ b/app/src/components/NodeManager/NodeItem.tsx
@@ -28,11 +28,15 @@ function NodeItem({ ...props }: NodeItem) {
       sx={{
         width: "100%",
         borderRadius: 25,
+        border: "1px solid",
+        borderColor: selected ? "black" : "gray",
         bgcolor: selected ? "#aaa" : "#eee",
         textTransform: "none", // Prevents text from being transformed to uppercase
         color: "inherit", // Keeps the original text color
         "&:hover": {
-          color: "inherit", // Maintains text color on hover
+          // Maintain colors on hover
+          color: "inherit",
+          borderColor: "inherit",
         },
       }}
     >

--- a/app/src/components/NodeManager/NodeManager.tsx
+++ b/app/src/components/NodeManager/NodeManager.tsx
@@ -28,8 +28,8 @@ function NodeManager({ ...props }: NodeManager) {
     );
   }
   return (
-    <Stack spacing={1}>
-      <Typography>Running Nodes</Typography>
+    <Stack spacing={1} sx={{ p: 2 }}>
+      <Typography variant="h6">Running Nodes</Typography>
       {nodeList}
     </Stack>
   );

--- a/app/src/css/App.css
+++ b/app/src/css/App.css
@@ -1,6 +1,7 @@
 #root {
-  max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 0;
   text-align: center;
+  background-color: #ddd;
+  min-height: 100dvh;
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2821,7 +2821,6 @@ vite-node@3.0.8:
     pathe "^2.0.3"
     vite "^5.0.0 || ^6.0.0"
 
-
 "vite@^5.0.0 || ^6.0.0", vite@^6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/vite/-/vite-6.2.3.tgz#249e92d32886981ab46bc1f049ac72abc6fa81e2"


### PR DESCRIPTION
This PR adds a couple of styling improvements that significantly improve the UI/UX of the HMI, aligning it more with my vision of what I want it to look like. This isn't perfect but this is significantly better than it was before and removes a couple of bugs that were really bugging me (no pun intended).

Main Changes:
- Added better overflow handling (so stuff will ... instead of going crazy, see before/after)
- Deleted the outer margins/max-width (this is primarily for a 800x480 7" screen)
- Changed the background color to de-emphasize the side and top panels
- Improved some spacing/padding/margins
- Made the console topic filter chips scrollable
- Changed the title of the console component from 'Messages from "/node"' to 'Console: /node'
- Changed some text to be headings
- Added borders to some elements
- Probably a few other small things I forgot, see before/after

Before:
![image](https://github.com/user-attachments/assets/71906b64-1d01-460e-9fdb-e550d52db2d0)

After:
![image](https://github.com/user-attachments/assets/caf8abd6-b721-4cdc-97dd-2e27a3863259)

Improved Overflow Handling (mainly for long topic names):
![image](https://github.com/user-attachments/assets/add1a173-6c2a-448c-ab63-3919e24e4b41)
